### PR TITLE
Do not lighten value text

### DIFF
--- a/envkey-assets/source/stylesheets/modules/environments/environments_grid/_cell.sass
+++ b/envkey-assets/source/stylesheets/modules/environments/environments_grid/_cell.sass
@@ -80,7 +80,7 @@
       margin: 0 15px
 
   .val-cols .cell
-    color: lighten($dark-text, 25%)
+    color: $dark-text
     border-bottom: 1px solid rgba(#000, 0.1)
     border-left: 1px solid rgba(#000, 0.1)
     text-align: center


### PR DESCRIPTION
I find not just the placeholder text to be too light, but the actual value text to be too light.

This darkens the value text to make it more readable.

Before:

![image](https://user-images.githubusercontent.com/824632/54780041-d0d9b280-4be6-11e9-848a-0259845b94ed.png)

After:

![image](https://user-images.githubusercontent.com/824632/54780056-da631a80-4be6-11e9-9340-ee5d48486839.png)


As an aside, I also think the text would benefit from being larger, but I have not included that change in this pull:

![image](https://user-images.githubusercontent.com/824632/54780117-f961ac80-4be6-11e9-8a9a-79bfb8e99653.png)
